### PR TITLE
CrossUp v1.0.1.4

### DIFF
--- a/stable/CrossUp/manifest.toml
+++ b/stable/CrossUp/manifest.toml
@@ -1,10 +1,9 @@
 [plugin]
 repository = "https://github.com/ItsBexy/CrossUp.git"
-commit = "d86d5912e617bef1dc5886a68f19d53c2896b6f6"
+commit = "d1c3cf1e70a91eb7c91c88c1b46263abb3f30eaa"
 owners = [
     "ItsBexy",
 ]
 changelog = """
-- If a hidden hotbar is switched to visible through use of CrossUp features, the plugin will no longer try to re-hide it later (it seems CrossUp was sometimes being a little too aggressive and hiding bars it shouldn't).
-- Under the hood stuff: made further adjustments to prevent errors on disposal/exit, and partially implemented IAddonLifeCycle
+- Small fix to ensure Expanded Hold bars behave correctly when the main menu is opened
 """


### PR DESCRIPTION
- Small fix to ensure Expanded Hold bars behave correctly when the main menu is opened